### PR TITLE
Updated NLog to latest version (dotnet standard port)

### DIFF
--- a/Moolah/Moolah/Moolah.csproj
+++ b/Moolah/Moolah/Moolah.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
     
   <ItemGroup>
-    <PackageReference Include="NLog" Version="2.0.0.2000" />
+    <PackageReference Include="NLog" Version="4.6.8" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
   </ItemGroup>


### PR DESCRIPTION
Updated NLog to latest version in order to fully support .net standard api (in scope of https://app.asana.com/0/902901911638987/1157002401038899)